### PR TITLE
implement seed data when application start

### DIFF
--- a/SimpleTodoList/Entities/DbInitializer.cs
+++ b/SimpleTodoList/Entities/DbInitializer.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SimpleTodoList.Entities
+{
+    public static class DbInitializer
+    {
+        public static IHost InitData(this IHost host)
+        {
+            using (var scope = host.Services.CreateScope())
+            {
+                var serviceProvider = scope.ServiceProvider;
+
+                InitializeAsync(serviceProvider).GetAwaiter().GetResult();
+            }
+            return host;
+        }
+
+        public static async Task InitializeAsync(IServiceProvider serviceProvider)
+        {
+            var context = serviceProvider.GetRequiredService<TodoDbContext>();
+
+            context.Database.EnsureCreated();
+
+            // Seed Todo
+            if (!context.Todos.Any())
+            {
+                var todos = new List<Todo>
+                {
+                    new Todo
+                    {
+                        Title = "Become a rock star developer",
+                        Description = "Do it now"
+                    },
+                   new Todo
+                   {
+                       Title = "Take fucking action",
+                       Description = "Do it now"
+                   }
+                };
+                context.Todos.AddRange(todos);
+                await context.SaveChangesAsync();
+            };
+        }
+    }
+}

--- a/SimpleTodoList/Program.cs
+++ b/SimpleTodoList/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SimpleTodoList.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace SimpleTodoList
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().InitData().Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
- For every created migration, we had to apply its changes manually. And this is quite okay. But when we deploy our application, it would be nice to have initial data at that moment in the database.

- What would be even nicer is that we don’t have to do that manually, but to start all the required migrations and seed all the required data as soon as the application starts.